### PR TITLE
Make ports configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,5 +2,6 @@ default['cups']['default_printer'] = nil
 default['cups']['printers'] = []
 default['cups']['systemgroups'] = "sys root"
 default['cups']['share_printers'] = true
+default['cups']['ports'] = [ 631 ]
 default['cups']['airprint']['airprint_generate']['git_url'] = 'https://github.com/tjfontaine/airprint-generate.git'
 default['cups']['airprint']['airprint_generate']['git_revision'] = 'master'

--- a/templates/default/cupsd.conf.erb
+++ b/templates/default/cupsd.conf.erb
@@ -16,12 +16,12 @@ SystemGroup <%= node['cups']['systemgroups'] %>
 
 <% if node['cups']['share_printers'] -%>
 # Allow remote access
-<% node['cups']['ports'],each do |port| -%>
+<% node['cups']['ports'].each do |port| -%>
 Port <%= port %>
 <%- end %>
 <% else -%>
 # Only listen for connections from the local machine.
-<% node['cups']['ports'],each do |port| -%>
+<% node['cups']['ports'].each do |port| -%>
 Listen localhost:<%= port %>
 <%- end %>
 <% end -%>

--- a/templates/default/cupsd.conf.erb
+++ b/templates/default/cupsd.conf.erb
@@ -16,10 +16,14 @@ SystemGroup <%= node['cups']['systemgroups'] %>
 
 <% if node['cups']['share_printers'] -%>
 # Allow remote access
-Port 631
+<% node['cups']['ports'],each do |port| -%>
+Port <%= port %>
+<%- end %>
 <% else -%>
 # Only listen for connections from the local machine.
-Listen localhost:631
+<% node['cups']['ports'],each do |port| -%>
+Listen localhost:<%= port %>
+<%- end %>
 <% end -%>
 Listen /var/run/cups/cups.sock
 


### PR DESCRIPTION
Allow configuration for cups server to listen on additional or different ports than 631 only eg. to listen on Port 80 and/or 443.