### PR TITLE
Make access rules configurable

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 default['cups']['default_printer'] = nil
 default['cups']['printers'] = []
 default['cups']['systemgroups'] = "sys root"
-default['cups']['share_printers'] = true
+default['cups']['share_printers'] = [ '@LOCAL' ]
 default['cups']['airprint']['airprint_generate']['git_url'] = 'https://github.com/tjfontaine/airprint-generate.git'
 default['cups']['airprint']['airprint_generate']['git_revision'] = 'master'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,5 +2,7 @@ default['cups']['default_printer'] = nil
 default['cups']['printers'] = []
 default['cups']['systemgroups'] = "sys root"
 default['cups']['share_printers'] = [ '@LOCAL' ]
+# ACLs like '.example.com' need DNS lookups
+default['cups']['hostname_lookups'] = false
 default['cups']['airprint']['airprint_generate']['git_url'] = 'https://github.com/tjfontaine/airprint-generate.git'
 default['cups']['airprint']['airprint_generate']['git_revision'] = 'master'

--- a/templates/default/cupsd.conf.erb
+++ b/templates/default/cupsd.conf.erb
@@ -39,6 +39,10 @@ BrowseAllow @LOCAL
 # Default authentication type, when authentication is required...
 DefaultAuthType Basic
 
+<% if node['cups']['hostname_lookups'] -%>
+HostNameLookups On
+<% end -%>
+
 # Restrict access to the server...
 <Location />
   Order allow,deny

--- a/templates/default/cupsd.conf.erb
+++ b/templates/default/cupsd.conf.erb
@@ -42,9 +42,8 @@ DefaultAuthType Basic
 # Restrict access to the server...
 <Location />
   Order allow,deny
-<% if node['cups']['share_printers'] -%>
-  # Allow shared printing...
-  Allow @LOCAL
+<% node['cups']['share_printers'].each do |acl| -%>
+  Allow <%= acl %>
 <% end -%>
 </Location>
 


### PR DESCRIPTION
The current cookbook statically configures `Allow @LOCAL` which restricts server access to the cups server's subnet.

This patch turns  the  `share_printers` attribute from boolean into an array with access patterns, eg. `[ '192.168.42.0/24', '.example.com', ... ]`