### PR TITLE
Printer databag feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,21 @@ SAMPLE format for printer entries:
 }
 ```
 
+##### Data bags
+
+Set the attribute `node['cups']['printer_bag']` to the name of your data bag.
+
+Data bag entries use this format:
+```
+{
+  "id": "printer1",
+  "model": "textonly.ppd",
+  "uri": "lpd://FQDN",
+  "location": "Front Office",
+  "desc": "HP LaserJet xx"
+}
+```
+
 #### cups::airprint
 Configures CUPS to advertise printers via AirPrint.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -2,6 +2,8 @@ default['cups']['default_printer'] = nil
 default['cups']['hostname_lookups'] = false
 default['cups']['loglevel'] = 'info'
 default['cups']['printers'] = []
+# a data bag to read printer configuration from:
+default['cups']['printer_bag'] = nil
 default['cups']['systemgroups'] = 'sys root'
 default['cups']['ports'] = [ 631 ]
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -61,9 +61,12 @@ end
 # Read more printers from databag:
 if node['cups']['printer_bag']
   data_bag(node['cups']['printer_bag']).each do |name|
+    # attribute-defined printers take precedence over databag-defined ones:
+    next if newprinters[name]
+
     # TODO: Add some method for filtering here?
     #  A regex for name matching? A special data bag attribute?
-    printers[name] = data_bag_item(node['cups']['printer_bag'], name)
+    newprinters[name] = data_bag_item(node['cups']['printer_bag'], name)
   end
 end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -45,7 +45,7 @@ lpstatcmd.run_command
 #
 #  Hash[lpstatcmd.stdout.scan(/^device for (.*?):\s(.*)/)] would also do the trick
 #   but as { name => device } instead of { name => { 'uri' => device } }
-#   the latter may be useful to add other info, eg. from lpootions
+#   the latter may be useful to add other info, eg. from lpoptions
 printers = lpstatcmd.stdout.scan(/^device for (.*?):\s(.*)/).inject({}) do |h,a|
   h[a[0]] = { 'uri' => a[1] }
   h
@@ -56,6 +56,15 @@ newprinters = node['cups']['printers'].inject({}) do |result,hash|
   printer = hash.first
   result[printer[0]] = printer[1]
   result
+end
+
+# Read more printers from databag:
+if node['cups']['printer_bag']
+  data_bag(node['cups']['printer_bag']).each do |name|
+    # TODO: Add some method for filtering here?
+    #  A regex for name matching? A special data bag attribute?
+    printers[name] = data_bag_item(node['cups']['printer_bag'], name)
+  end
 end
 
 newprinters.each do |name,config|


### PR DESCRIPTION
I just implemented handling of data bags for printer configuration. I took the chance to cleanup the printer and oldprinter data structures. Node attributes take precedence over data bags, so nothing should get broken.

This also allows to fix #5. I'd prepare a 2nd PR after this one gets merged.