### PR TITLE
Allow setting the ServerAlias directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Attributes
     <td>The full path to the SSL key file to be used by cups.</td>
     <td><tt>nil</tt></td>
   </tr>
+  <tr>
+    <td><tt>['cups']['server_aliases']</tt></td>
+    <td>array</td>
+    <td>List of allowed domains for remote administration</td>
+    <td><tt>[]</tt></td>
+  </tr>
 </table>
 
 #### cups::airprint

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,6 +16,9 @@ default['cups']['share_printers'] = [ '@LOCAL' ]
 # ACLs like '.example.com' need DNS lookups
 default['cups']['hostname_lookups'] = false
 
+# allowed HTTP Host: headers
+default['cups']['server_aliases'] = [ ]
+
 # ACLs for remote administration -- default is localhost only
 default['cups']['admin']['acl'] = [ ]
 

--- a/templates/debian-8/cupsd.conf.erb
+++ b/templates/debian-8/cupsd.conf.erb
@@ -14,6 +14,10 @@ MaxLogSize 0
 # Printer Administrator user group:
 SystemGroup <%= node['cups']['systemgroups'] %>
 
+<% node['cups']['server_aliases'].each do |server_alias| -%>
+ServerAlias <%= server_alias %>
+<% end -%>
+
 <% if node['cups']['share_printers'] -%>
 # Allow remote access
 Port 631

--- a/templates/default/cupsd.conf.erb
+++ b/templates/default/cupsd.conf.erb
@@ -13,6 +13,9 @@ LogLevel <%= node['cups']['loglevel'] %>
 # Administrator user group...
 SystemGroup <%= node['cups']['systemgroups'] %>
 
+<% node['cups']['server_aliases'].each do |server_alias| -%>
+ServerAlias <%= server_alias %>
+<% end -%>
 
 <% if node['cups']['share_printers'] -%>
 # Allow remote access


### PR DESCRIPTION
This allows the server to be administered remotely via a known hostname,
if for some reason you can't/don't want to access the cups interface via
localhost or the automatically generated hostname.