### PR TITLE
Added support for opening firewall ports

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,8 @@ source_url       'https://github.com/biola/chef-cups'
 issues_url       'https://github.com/biola/chef-cups/issues'
 version          '0.6.0'
 
-depends 'git', '~> 4.0'
+depends 'git',      '~> 4.0'
+depends 'firewall', '~> 2.2.0'
 
 %w(ubuntu debian redhat centos amazon scientific smartos).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -94,3 +94,10 @@ newprinters.each do |name, config|
     not_if { printers.key?(name) && printers[name]['uri'] == config['uri'] }
   end
 end
+
+# Open ports for CUPS
+firewall_rule 'cups' do
+  protocol :tcp
+  port node['cups']['ports'] 
+  not_if { node['cups']['share_printers'] == [ '@LOCAL' ] }
+end


### PR DESCRIPTION
Enable the opening of firewall ports for each of the listening ports.  No ports are opened if the printer ACLs are set to ```@LOCAL```.