### PR TITLE
Added support for SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,54 @@ Attributes
     <td>Should cups share printers?</td>
     <td><tt>true</tt></td>
   </tr>
+  <tr>
+    <td><tt>['cups']['require_encryption']</tt></td>
+    <td>boolean</td>
+    <td>Should cups require encryption for clients?  This requires a certificate to be already in a data bag (preferably encrypted using <tt>chef-vault</tt>) as defined in the <a href="https://supermarket.chef.io/cookbooks/certificate">certificate</a> cookbook.</td>
+    <td><tt>false</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['cups']['certificate']['data_bag']</tt></td>
+    <td>string</td>
+    <td>If <tt>require_encryption</tt> is set then this is the databag that contains the certificate as used by the <a href="https://supermarket.chef.io/cookbooks/certificate">certificate</a> cookbook.</td>
+    <td><tt>nil</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['cups']['certificate']['data_bag_type']</tt></td>
+    <td>string</td>
+    <td>The data bag type of <tt>['cups']['certificate']['data_bag']</tt>, can any type supported by the <a href="https://supermarket.chef.io/cookbooks/certificate">certificate</a> cookbook.</td>
+    <td><tt>unencrypted</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['cups']['certificate']['search_id']</tt></td>
+    <td>string</td>
+    <td>The <tt>search_id</tt> as used by the <a href="https://supermarket.chef.io/cookbooks/certificate">certificate</a> cookbook.</td>
+    <td><tt>cups</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['cups']['certificate']['cert_file']</tt></td>
+    <td>string</td>
+    <td>The name of the certificate file as used by the <a href="https://supermarket.chef.io/cookbooks/certificate">certificate</a> cookbook.</td>
+    <td><tt>#{node['fqdn']}.pem</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['cups']['certificate']['key_file']</tt></td>
+    <td>string</td>
+    <td>The name of the certificate key file as used by the <a href="https://supermarket.chef.io/cookbooks/certificate">certificate</a> cookbook.</td>
+    <td><tt>#{node['fqdn']}.key</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['cups']['certificate']['chain_file']</tt></td>
+    <td>string</td>
+    <td>The name of the certificate chain file as used by the <a href="https://supermarket.chef.io/cookbooks/certificate">certificate</a> cookbook.</td>
+    <td><tt>#{node['fqdn']}.pem</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['cups']['certificate']['cert_path']</tt></td>
+    <td>string</td>
+    <td>The path where the above certificates will be stored.</td>
+    <td><tt>/etc/cups/ssl</tt></td>
+  </tr>
 </table>
 
 #### cups::airprint

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,14 @@ default['cups']['printers'] = []
 default['cups']['printer_bag'] = nil
 default['cups']['systemgroups'] = 'sys root'
 default['cups']['ports'] = [ 631 ]
+default['cups']['require_encryption'] = false
+default['cups']['certificate']['data_bag'] = nil
+default['cups']['certificate']['data_bag_type'] = 'unencrypted'
+default['cups']['certificate']['search_id'] = 'cups'
+default['cups']['certificate']['cert_file'] = "#{node['fqdn']}.pem"
+default['cups']['certificate']['key_file'] = "#{node['fqdn']}.key"
+default['cups']['certificate']['chain_file'] = "#{node['hostname']}-bundle.crt"
+default['cups']['certificate']['cert_path'] = '/etc/cups/ssl'
 
 # ACLs for printer access:
 default['cups']['share_printers'] = [ '@LOCAL' ]

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,8 @@ source_url       'https://github.com/biola/chef-cups'
 issues_url       'https://github.com/biola/chef-cups/issues'
 version          '0.6.0'
 
-depends 'git', '~> 4.0'
+depends 'git',         '~> 4.0'
+depends 'certificate', '~> 1.0'
 
 %w(ubuntu debian redhat centos amazon scientific smartos).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,19 @@
 # limitations under the License.
 #
 #
+
 package 'cups'
+
+certificate_manage 'cups' do
+  data_bag node['cups']['certificate']['data_bag']
+  data_bag_type node['cups']['certificate']['data_bag_type']
+  search_id node['cups']['certificate']['search_id']
+  cert_file node['cups']['certificate']['cert_file']
+  key_file node['cups']['certificate']['key_file']
+  chain_file node['cups']['certificate']['chain_file']
+  cert_path node['cups']['certificate']['cert_path']
+  only_if { node['cups']['require_encryption'] == true }
+end
 
 template '/etc/cups/cupsd.conf' do
   owner 'root'

--- a/templates/debian-8/cupsd.conf.erb
+++ b/templates/debian-8/cupsd.conf.erb
@@ -23,6 +23,13 @@ Listen localhost:631
 <% end -%>
 Listen /var/run/cups/cups.sock
 
+<% if node['cups']['require_encryption'] -%>
+# Require SSL/TLS for printer sharing
+Encryption Required
+ServerCertificate <%= node['cups']['certificate']['cert_path'] %>/<%= node['cups']['certificate']['cert_file'] %>
+ServerKey <%= node['cups']['certificate']['cert_path'] %>/<%= node['cups']['certificate']['cert_file'] %>
+<% end -%>
+
 # Show shared printers on the local network.
 Browsing On
 BrowseLocalProtocols dnssd

--- a/templates/default/cupsd.conf.erb
+++ b/templates/default/cupsd.conf.erb
@@ -27,6 +27,13 @@ Listen localhost:<%= port %>
 <% end -%>
 Listen /var/run/cups/cups.sock
 
+<% if node['cups']['require_encryption'] -%>
+# Require SSL/TLS for printer sharing
+Encryption Required
+ServerCertificate <%= node['cups']['certificate']['cert_path'] %>/<%= node['cups']['certificate']['cert_file'] %>
+ServerKey <%= node['cups']['certificate']['cert_path'] %>/<%= node['cups']['certificate']['cert_file'] %>
+<% end -%>
+
 <% if node['cups']['share_printers'] -%>
 # Show shared printers on the local network.
 Browsing On


### PR DESCRIPTION
Add support for SSL with CUPs.  We use IPP from cloud services to on-premises printers, so SSL is desirable for submission of jobs.  Uses the [certificate](https://supermarket.chef.io/cookbooks/certificate) cookbook for the storage of certificates.